### PR TITLE
fix: update incorrect github oauth base uri

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,7 +59,7 @@ TWITCH_OAUTH_SECRET=""
 TWITCH_OAUTH_SCOPES="user:read:email"
 
 
-GITHUB_OAUTH_BASE_URI="https://id.twitch.tv/oauth2"
+GITHUB_OAUTH_BASE_URI="https://github.com/login/oauth/authorize"
 GITHUB_OAUTH_ID=""
 GITHUB_REDIRECT_URI="http://localhost:8000/auth/oauth/github"
 GITHUB_OAUTH_SECRET=""


### PR DESCRIPTION
Fixes the `GITHUB_OAUTH_BASE_URI` key on `.env.example`